### PR TITLE
Add LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019-2022 courvoif
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Hi @courvoif,

We've been using your `pcap-file` crate in [Packetry](https://github.com/greatscottgadgets/packetry/) and we're very happy with it. As part of our release preparations, I've been going through the license requirements for all of our dependencies, including `byteorder_slice`.

Currently `byteorder_slice` declares an MIT license type in `Cargo.toml`, but there's no license file in the repository, nor in its released crates.

The terms of the MIT license require us to include both your original copyright notice, and the original license text, when we distribute our program. Because these are missing we can't technically comply with that requirement.

This PR adds the necessary LICENSE file, using the same text as the one you have for `pcap-file`. I have set the copyright dates based on the commits in this repository.